### PR TITLE
add test for interactive prompt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
         sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
         sudo apt update
         sudo apt install postgresql-10
+        sudo cat /etc/postgresql/10/main/pg_hba.conf
 
     - name: Install pgsu
       run: |

--- a/README.md
+++ b/README.md
@@ -10,27 +10,26 @@ Use this module e.g. to create databases and database users from a command line 
 
 ## Features
 
- * autodetects postgres setup
- * uses [psycopg2](http://initd.org/psycopg/docs/index.html) to connect where possible
- * can use `sudo` to become the `postgres` UNIX user if necessary/possible
- * tested via continuous integration on
+ * autodetects postgres setup, tested on
    * [Ubuntu 18.04](https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1804-README.md) & PostgreSQL installed via `apt`
    * [Ubuntu 18.04](https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1804-README.md) & PostgreSQL docker container
    * [MacOS 10.15](https://github.com/actions/virtual-environments/blob/master/images/macos/macos-10.15-Readme.md) and PostgreSQL installed via `conda`
    * [Windows Server 2019](https://github.com/actions/virtual-environments/blob/master/images/win/Windows2019-Readme.md) and PostgreSQL installed via `conda`
+ * uses [psycopg2](http://initd.org/psycopg/docs/index.html) to connect where possible
+ * can use `sudo` to become the `postgres` UNIX user if necessary/possible (Ubuntu setups)
    
 ## Usage
 
 ### Python API
 ```python
 from pgsu import PGSU
-pgsu = PGSU()  # this may prompt for sudo password
+pgsu = PGSU()  # On Ubuntu, this may prompt for sudo password
 pgsu.execute("CREATE USER newuser WITH PASSWORD 'newpassword'")
 users = pgsu.execute("SELECT usename FROM pg_user WHERE usename='newuser'")
 print(users)
 ```
 
-While the main point of the package is to *guess* the PostgreSQL setup, you can also provide partial or all information abut the setup using the `dsn` parameter.
+While the main point of the package is to *guess* how to connect as a postgres superuser, you can also provide partial or all information abut the setup using the `dsn` parameter.
 These are the default settings:
 ```python
 from pgsu import PGSU

--- a/pgsu/cli.py
+++ b/pgsu/cli.py
@@ -14,8 +14,7 @@ GET_DBS_COMMAND = "SELECT datname FROM pg_database"
 @click.argument('query', type=str, default=GET_DBS_COMMAND)
 def run(query):
     """Execute SQL command as PostrgreSQL superuser."""
-    click.echo("Trying to connect to PostgreSQL...")
-    pgsu = PGSU()
+    pgsu = PGSU(interactive=True, quiet=False)
     click.echo("Executing query: {}".format(query))
     dbs = pgsu.execute(query)
     click.echo(pprint.pformat(dbs))

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,18 @@ setup(
     url='https://github.com/ltalirz/pgsu',
     author='AiiDA Team',
     author_email='aiidateam@gmail.com',
+    classifiers=[
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: POSIX :: Linux",
+        "Operating System :: MacOS :: MacOS X",
+        "Operating System :: Microsoft :: Windows",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+    ],
     license='MIT',
     packages=find_packages(),
     install_requires=[


### PR DESCRIPTION
fixes #8 
fixes #11

 * Add test for interactive prompt
 * Stop forcing host variable to localhost on all platforms
 * Make prompting *actually* work
 * switch to using logger instead of passing `quiet` variable around